### PR TITLE
fix(external-cli): passthrough help and version flags

### DIFF
--- a/crates/autocli-cli/src/main.rs
+++ b/crates/autocli-cli/src/main.rs
@@ -82,7 +82,16 @@ fn build_cli(registry: &Registry, external_clis: &[ExternalCli]) -> Command {
         app = app.subcommand(
             Command::new(ext.name.clone())
                 .about(ext.description.clone())
-                .allow_external_subcommands(true),
+                .disable_help_flag(true)
+                .disable_version_flag(true)
+                .arg(
+                    Arg::new("args")
+                        .num_args(0..)
+                        .trailing_var_arg(true)
+                        .allow_hyphen_values(true)
+                        .value_parser(clap::builder::OsStringValueParser::new())
+                        .help("Arguments passed through to the external CLI"),
+                ),
         );
     }
 
@@ -990,17 +999,10 @@ async fn main() {
 
         // Check if it's an external CLI
         if let Some(ext) = external_clis.iter().find(|e| e.name == site_name) {
-            // Gather remaining args for the external CLI
-            let ext_args: Vec<String> = match site_matches.subcommand() {
-                Some((sub, sub_matches)) => {
-                    let mut args = vec![sub.to_string()];
-                    if let Some(rest) = sub_matches.get_many::<std::ffi::OsString>("") {
-                        args.extend(rest.map(|s| s.to_string_lossy().to_string()));
-                    }
-                    args
-                }
-                None => vec![],
-            };
+            let ext_args: Vec<String> = site_matches
+                .get_many::<std::ffi::OsString>("args")
+                .map(|vals| vals.map(|s| s.to_string_lossy().to_string()).collect())
+                .unwrap_or_default();
 
             match autocli_external::execute_external_cli(&ext.name, &ext.binary, &ext_args)
                 .await


### PR DESCRIPTION
## Summary

Forward `--help` and `--version` to external CLIs instead of handling them at the AutoCLI wrapper layer.

## Problem

For external CLIs, commands like "--help", "--version" were intercepted by AutoCLI's wrapper parsing instead of reaching the underlying CLI directly.

```sh
$ gh --version
gh version 2.88.1 (2026-03-12)
https://github.com/cli/cli/releases/tag/v2.88.1

$ autocli --version
autocli 0.3.7

$ autocli gh --version
error: unexpected argument '--version' found

  tip: a similar argument exists: '--verbose'

Usage: autocli.exe gh --verbose

For more information, try '--help'.

$ gh --help
Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
...

$ autocli gh --help
GitHub CLI — repos, PRs, issues, releases, gists

Usage: autocli.exe gh [OPTIONS] [COMMAND]

Options:
  -f, --format <format>  Output format: table, json, yaml, csv, md [default: table]
  -v, --verbose          Enable verbose output
  -h, --help             Print help

$ autocli --help
AI-driven CLI tool — turns websites into command-line interfaces

Usage: autocli.exe [OPTIONS] [COMMAND]

Commands:
  antigravity
  apple-podcasts
  arxiv
...
```

## Changes

 - disable wrapper-level `--help` handling for external CLI subcommands
 - disable wrapper-level `--version` handling for external CLI subcommands
 - pass trailing args through directly to the external binary

## Result

 External CLIs now behave more like native commands and align better with user and agent expectations.

```sh
$ autocli --version
autocli 0.3.7

$ autocli gh --version
gh version 2.88.1 (2026-03-12)
https://github.com/cli/cli/releases/tag/v2.88.1

$ gh --version
gh version 2.88.1 (2026-03-12)
https://github.com/cli/cli/releases/tag/v2.88.1

$ autocli --help
AI-driven CLI tool — turns websites into command-line interfaces

Usage: autocli.exe [OPTIONS] [COMMAND]

Commands:
  antigravity
  apple-podcasts
  arxiv
...

$ autocli gh --help
Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
...
```

