### PR TITLE
fix: detect Chromium process on macOS in is_chrome_running()

### DIFF
--- a/crates/autocli-browser/src/bridge.rs
+++ b/crates/autocli-browser/src/bridge.rs
@@ -170,9 +170,9 @@ impl BrowserBridge {
 /// Check if Chrome/Chromium is running as a process.
 fn is_chrome_running() -> bool {
     if cfg!(target_os = "macos") {
-        // macOS: check for "Google Chrome" process
+        // macOS: check for "Google Chrome" or "Chromium" process
         std::process::Command::new("pgrep")
-            .args(["-x", "Google Chrome"])
+            .args(["-x", "-E", "^Google Chrome$|^Chromium$"])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()


### PR DESCRIPTION
macOS pgrep was only checking for 'Google Chrome' but ungoogled-chromium launches as 'Chromium' process, causing autocli to falsely report 'Chrome is not running'.

Changed pgrep args from `-x 'Google Chrome'` to `-x -E '^Google Chrome$|^Chromium$'` to match both process names.